### PR TITLE
Bug fix: obtain real screen resolution instead of app resolution

### DIFF
--- a/app/src/main/java/com/draco/resolutionchanger/MainActivity.kt
+++ b/app/src/main/java/com/draco/resolutionchanger/MainActivity.kt
@@ -78,7 +78,7 @@ class MainActivity : AppCompatActivity() {
         /* Set DefaultScreenSpecs to current settings */
         fun setup(windowManager: WindowManager) {
             val dm = DisplayMetrics()
-            windowManager.defaultDisplay.getMetrics(dm)
+            windowManager.defaultDisplay.getRealMetrics(dm)
 
             width = dm.widthPixels
             height = dm.heightPixels


### PR DESCRIPTION
App obtained "app resolution" instead of "screen resolution". This caused improper detection of screen resolution and the unintended behavior or unable to change screen resolution. The fix is tested on Xiaomi Mix 3 running Android 10 based MIUI 11.